### PR TITLE
fix to work SpyOn in Jasmine

### DIFF
--- a/spec/cli.spec.js
+++ b/spec/cli.spec.js
@@ -18,6 +18,22 @@
 const fs = require('fs');
 const path = require('path');
 const rewire = require('rewire');
+/*
+    After Cordova-Common 3.1.0, logger[level] property becomes not writable.
+    Therefore we re-define addLevel function here to use SpyOn logger[level]
+*/
+const CordovaLogger = require('cordova-common').CordovaLogger;
+CordovaLogger.prototype.addLevel = function (level, severity, color) {
+    this.levels[level] = severity;
+    if (color) {
+        this.colors[level] = color;
+    }
+    // Define own method with corresponding name
+    if (!this[level]) {
+        this[level] = this.log.bind(this, level);
+    }
+    return this;
+};
 const { events, cordova } = require('cordova-lib');
 const logger = require('cordova-common').CordovaLogger.get();
 const telemetry = require('../src/telemetry');


### PR DESCRIPTION
### Platforms affected
All platforms. But tests only

### What does this PR do?
At the Cordova-Common 3.1.0, the logger[level] property becomes not writable. (level = results, verbose, normal, warn, info, error)
Then we can't use SpyOn for logger[level] in jasmine tests.

Actually `npm run tests` fails like
```
    Error: <spyOn> : results is not declared writable or has no setter
    Usage: spyOn(<object>, <methodName>)
```

To resolve this issue, this PR overrides `CordovaLogger.prototype.addLevel` method in test code (i.e. `cli.spec.js`) to make logger[level] property writable.

### What testing has been done on this change?

```
npm run test
```

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
